### PR TITLE
Now need closing </class> in xml

### DIFF
--- a/plugin_description.xml
+++ b/plugin_description.xml
@@ -3,4 +3,5 @@
          type="rviz_ortho_view_controller::OrthoViewController"
          base_class_type="rviz::ViewController">
     <description>An orthographic view controller</description>
+  </class>
 </library>


### PR DESCRIPTION
Without closing the class an error results: 'Skipped loading plugin with error.. has no Root Element. This likely means the XML is malformed or missing error' (must be a recent change to class loader)