### PR TITLE
Left button scroll mode

### DIFF
--- a/include/rviz_ortho_view_controller/ortho_view_controller.h
+++ b/include/rviz_ortho_view_controller/ortho_view_controller.h
@@ -7,6 +7,7 @@
 
 namespace rviz
 {
+class BoolProperty;
 class EnumProperty;
 class FloatProperty;
 class QuaternionProperty;
@@ -56,6 +57,7 @@ private:
   rviz::VectorProperty *centre_property_;
   rviz::QuaternionProperty *orientation_property_;
   rviz::FloatProperty *scale_property_;
+  rviz::BoolProperty *scroll_property_;
 
   bool dragging_ = false;
 


### PR DESCRIPTION
Adds a mode where the left mouse button drags/scrolls the view around without changing rotation (and the middle button behaves as the left used to).